### PR TITLE
Github repos from SSH to HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@
 
 # Sass-output.
 .sass-cache
-/config/ssh_keys/*

--- a/app/forms/project_form.rb
+++ b/app/forms/project_form.rb
@@ -29,7 +29,7 @@ class ProjectForm
     create_slack_channel
     create_github_team
     invite_to_github_team
-    create_and_fork_repo
+    create_and_clone_repo
   end
 
   private
@@ -68,7 +68,7 @@ class ProjectForm
     github.invite_to_team(team_id, username)
   end
 
-  def create_and_fork_repo
+  def create_and_clone_repo
     args = {
       name: name,
       description: description,
@@ -76,6 +76,6 @@ class ProjectForm
     }
     repo_results = github.create_org_repo(args)
     github.add_repo_to_team(project.github_team_id, repo_results["name"])
-    github.fork_repo(name, repo_results["full_name"] + ".git")
+    github.clone_repo(name, repo_results["full_name"])
   end
 end

--- a/lib/github_adapter.rb
+++ b/lib/github_adapter.rb
@@ -35,14 +35,15 @@ class GithubAdapter
     resource.put( { permission: "admin" }.to_json, content_type: "application/json")
   end
 
-  def fork_repo(project_name, full_name_git)
+  def clone_repo(project_name, full_name)
+    root_repo_uri = "https://#{user}:#{password}@github.com/#{ENV['ROOT_REPO_URI']}.git"
+    new_repo_uri  = "https://#{user}:#{password}@github.com/#{full_name}.git"
     system(
       "sh",
-      ENV["CHATTO_HUB_ADMIN_GIT_FORK_SH"],
-      ENV["CHATTO_HUB_ADMIN_GIT_USER"],
-      ENV["ROOT_REPO_URI"],
+      Rails.root.join('lib','scripts','chatto_hub_clone.sh').to_s,
+      root_repo_uri,
       project_name,
-      full_name_git
+      new_repo_uri
     )
   end
 

--- a/lib/scripts/chatto_hub_clone.sh
+++ b/lib/scripts/chatto_hub_clone.sh
@@ -5,10 +5,10 @@ then
     mkdir repos 
 fi
 cd repos
-git clone "$1:$2" $3
-cd $3
-git remote add new-origin "$1:$4"
+git clone $1 $2
+cd $2
+git remote add new-origin $3
 git push new-origin master
 
 cd ..
-rm -rf $3
+rm -rf $2

--- a/spec/forms/project_form_spec.rb
+++ b/spec/forms/project_form_spec.rb
@@ -106,7 +106,7 @@ def github_persist_double
     create_team: { "id" => 42 },
     invite_to_team: true,
     create_org_repo: { "name" => "username", "full_name" => "github_repo.git" },
-    fork_repo: true,
+    clone_repo: true,
     add_repo_to_team: true
   )
 end
@@ -115,5 +115,5 @@ def stub_slack_and_github!(form)
   allow(form).to receive(:create_slack_channel).and_return(true)
   allow(form).to receive(:create_github_team).and_return(true)
   allow(form).to receive(:invite_to_github_team).and_return(true)
-  allow(form).to receive(:create_and_fork_repo).and_return(true)
+  allow(form).to receive(:create_and_clone_repo).and_return(true)
 end

--- a/spec/lib/github_adapter_spec.rb
+++ b/spec/lib/github_adapter_spec.rb
@@ -57,23 +57,10 @@ describe GithubAdapter do
     end
   end
 
-  describe "#fork_repo" do
-    before do
-      ENV["CHATTO_HUB_ADMIN_GIT_FORK_SH"] = "fork_sh"
-      ENV["CHATTO_HUB_ADMIN_GIT_USER"] = "git_user"
-      ENV["ROOT_REPO_URI"] = "root_repo"
-    end
-
+  describe "#clone_repo" do
     it "executes sh script" do
-      expect(subject).to receive(:system).with(
-        "sh",
-        "fork_sh",
-        "git_user",
-        "root_repo",
-        "example_project",
-        "example_project.git"
-      )
-      subject.fork_repo("example_project", "example_project.git")
+      expect(subject).to receive(:system)
+      subject.clone_repo("example_project", "example_project.git")
     end
   end
 end


### PR DESCRIPTION
Changed github repo cloning to use HTTPS in order to remove ssh keys and make deployment easier.
